### PR TITLE
fix: surface contains_sensitive_data in report metadata

### DIFF
--- a/src/mcp/format.ts
+++ b/src/mcp/format.ts
@@ -13,6 +13,7 @@ interface SamplingMeta {
     total_rows?: number
     total_rows_rounded?: boolean
     sampled?: boolean
+    contains_sensitive_data?: boolean
     sample_share?: number
     sample_size?: number
     sample_space?: number
@@ -29,6 +30,7 @@ function buildMeta(
         returned_rows: returnedRows,
         sampled: resp.sampled ?? false,
         sample_share: resp.sample_share ?? null,
+        contains_sensitive_data: resp.contains_sensitive_data ?? false,
         data_lag_seconds: resp.data_lag ?? null,
     }
 }

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -104,6 +104,17 @@ describe('formatDataResponse', () => {
         expect(out.sampling_notice).toContain('sample')
         expect((out.meta as Record<string, unknown>).sampled).toBe(true)
     })
+
+    it('surfaces contains_sensitive_data in metadata', () => {
+        const limited = {
+            ...resp,
+            contains_sensitive_data: true,
+        } as unknown as DataResponse
+        const out = formatDataResponse(limited, [], ['ym:s:visits'], false)
+        expect(
+            (out.meta as Record<string, unknown>).contains_sensitive_data,
+        ).toBe(true)
+    })
 })
 
 describe('formatComparisonResponse', () => {


### PR DESCRIPTION
## Problem

Yandex Metrica Reporting API responses include the
`contains_sensitive_data` metadata field.

The response schemas already parse this field, but `SamplingMeta` and
`buildMeta()` omit it when producing MCP structured output. As a result,
MCP clients cannot tell when Yandex Metrica applied limited-disclosure rules
to a report.

## Change

- add `contains_sensitive_data` to `SamplingMeta`;
- expose it under the existing `meta` object;
- default to `false` when the API omits the field;
- add a formatter regression test.

## Behavior

No report data is blocked or changed. This PR only preserves metadata already
returned by the Yandex Metrica API.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun test` (79 passed)
- `bun run build`

## Reference

https://yandex.ru/dev/metrika/en/stat/
